### PR TITLE
Add the 'albatross' package

### DIFF
--- a/ChemPhys.md
+++ b/ChemPhys.md
@@ -84,6 +84,10 @@ if a new package or function should be mentioned here.
     for concentration-response, dose-response and time-response data.
 -   The package `r pkg("mdatools")` provides functions for MCR-ALS with constraints 
     and a purity based methods similar to SIMPLISMA.   
+-   The `r pkg("albatross")` package specialises in non-negative
+    Parallel Factor Analysis of fluorescence excitation-emission
+    matrices and provides auxillary functions relevant to analysis of
+    natural waters.
 
 ### Partial Least Squares
 


### PR DESCRIPTION
Dear Katharine Mullen,

Could you please consider the `albatross` package for inclusion in the ChemPhys Task View? It has been on CRAN since 2020, has more lines of tests and documentation than code and has a low dependency footprint.